### PR TITLE
Agrupa horários das disciplinas em 1 único evento no export para calendário + melhorias gerais

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ O **QueHoraÉEssa?** facilita a vida do estudante da UFBA ao transformar código
 - **Compatibilidade Total**: Exportação para Google Calendar, Outlook e outros calendários
 - **Formato iCalendar (.ics)**: Arquivo padrão compatível com todos os calendários digitais
 - **Eventos Recorrentes**: Configuração automática de repetição semanal
+- **Agrupamento de Horários**: Cria um único evento para as aulas de cada matéria no dia
 - **Informações Completas**: Inclui código da disciplina, nome, professor e horários
 
 ### 💾 Persistência e Sincronização

--- a/src/components/GradeHoraria.tsx
+++ b/src/components/GradeHoraria.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Disciplina } from "@/utils/sigaaParser";
@@ -6,6 +6,7 @@ import { detectConflicts } from "@/utils/sigaaParser";
 import { Trash2, AlertTriangle, Clock, User, BookOpen, Calendar, ArrowDown, ArrowUp } from "lucide-react";
 import React from "react";
 import { Switch } from "@/components/ui/switch";
+import { HORARIOS_BLOCOS } from "@/types/schedule";
 
 interface GradeHorariaProps {
   disciplinas: Disciplina[];
@@ -20,13 +21,6 @@ const HORARIOS_GRADE = [
 ];
 
 const DIAS_SEMANA = ['SEG', 'TER', 'QUA', 'QUI', 'SEX', 'SAB'];
-
-// Mapeamento de horários para blocos do SIGAA (baseado na tabela UFBA)
-const HORARIO_PARA_BLOCO: { [key: string]: string } = {
-  '07:00': 'M1', '07:55': 'M2', '08:50': 'M3', '09:45': 'M4', '10:40': 'M5', '11:35': 'M6',
-  '13:00': 'T1', '13:55': 'T2', '14:50': 'T3', '15:45': 'T4', '16:40': 'T5', '17:35': 'T6',
-  '18:30': 'N1', '19:25': 'N2', '20:20': 'N3', '21:15': 'N4'
-};
 
 // Função para converter dia do SIGAA para formato iCal
 const getDiaSigaaParaICal = (dia: string): string => {
@@ -275,7 +269,7 @@ export const GradeHoraria = ({ disciplinas, onRemoverDisciplina, compact = false
                 const [dia, bloco] = key.split('-');
                 return (
                     <div key={key} className="flex items-center gap-2 flex-wrap mb-1">
-                      <span className="font-medium text-red-700 text-xs">{dia} {bloco}:</span>
+                      <span className="font-medium text-red-700 text-xs">{dia} {bloco} ({HORARIOS_BLOCOS[bloco]}):</span>
                       {disciplinasCodigos.map((codigo) => {
                         const disciplina = disciplinas.find(d => d.codigo === codigo);
                         if (!disciplina) return null;

--- a/src/components/GradeHoraria.tsx
+++ b/src/components/GradeHoraria.tsx
@@ -1,12 +1,9 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Disciplina } from "@/utils/sigaaParser";
 import { detectConflicts } from "@/utils/sigaaParser";
-import { Trash2, Info, AlertTriangle, Clock, User, BookOpen, ChevronDown, ChevronUp, ExternalLink, Calendar } from "lucide-react";
+import { Trash2, AlertTriangle, Clock, User, BookOpen, Calendar, ArrowDown, ArrowUp } from "lucide-react";
 import React from "react";
 import { Switch } from "@/components/ui/switch";
 
@@ -138,23 +135,8 @@ const baixarArquivo = (conteudo: string, nomeArquivo: string) => {
 
 export const GradeHoraria = ({ disciplinas, onRemoverDisciplina, compact = false, showNames = true }: GradeHorariaProps) => {
   const [selectedDisciplina, setSelectedDisciplina] = useState<Disciplina | null>(null);
-  const [selectedConflictCell, setSelectedConflictCell] = useState<string | null>(null);
   const [conflictsOpen, setConflictsOpen] = useState(false);
   const [showDetailed, setShowDetailed] = useState(compact ? false : !compact);
-  const [showTutorialModal, setShowTutorialModal] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
-  
-  // Detecta se é mobile
-  useEffect(() => {
-    const checkIsMobile = () => {
-      setIsMobile(window.innerWidth < 768);
-    };
-    
-    checkIsMobile();
-    window.addEventListener('resize', checkIsMobile);
-    
-    return () => window.removeEventListener('resize', checkIsMobile);
-  }, []);
   
   const conflicts = detectConflicts(disciplinas);
   
@@ -283,7 +265,8 @@ export const GradeHoraria = ({ disciplinas, onRemoverDisciplina, compact = false
         <div className="flex flex-col items-center justify-center w-full my-2">
           <div className="flex items-center gap-1 text-red-800 font-bold text-xs md:text-base">
             <AlertTriangle className="h-5 w-5 mr-1 text-red-500" />
-            <span>Conflito de Horários Detectados</span>
+            <span>Conflito de Horários Detectado</span>
+            {conflictsOpen ? <ArrowUp className="h-5 w-5 cursor-pointer" onClick={() => setConflictsOpen(false)}/> : <ArrowDown className="h-5 w-5 cursor-pointer" onClick={() => setConflictsOpen(true)} />}
           </div>
           {conflictsOpen && (
             <div className="pt-1 pb-2">

--- a/src/pages/EscalaAtual.tsx
+++ b/src/pages/EscalaAtual.tsx
@@ -19,14 +19,12 @@ const Grade = () => {
   // Carrega a grade do localStorage ao inicializar
   useEffect(() => {
     const gradeSalva = localStorage.getItem('gradeHoraria');
-    console.log('gradeSalva', gradeSalva);
     if (gradeSalva) {
       setGradeAtual(JSON.parse(gradeSalva));
     }
     
     // Carrega histórico de grades salvas
     const historicoGradesSalvo = localStorage.getItem('historicoGrades');
-    console.log('historicoGradesSalvo', historicoGradesSalvo);
     if (historicoGradesSalvo) {
       setHistoricoGrades(JSON.parse(historicoGradesSalvo));
     }

--- a/src/pages/EscalaAtual.tsx
+++ b/src/pages/EscalaAtual.tsx
@@ -1,10 +1,8 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { 
   Trash2,
-  BookOpen,
-  ExternalLink,
   Download,
   History
 } from "lucide-react";
@@ -21,12 +19,14 @@ const Grade = () => {
   // Carrega a grade do localStorage ao inicializar
   useEffect(() => {
     const gradeSalva = localStorage.getItem('gradeHoraria');
+    console.log('gradeSalva', gradeSalva);
     if (gradeSalva) {
       setGradeAtual(JSON.parse(gradeSalva));
     }
     
     // Carrega histórico de grades salvas
     const historicoGradesSalvo = localStorage.getItem('historicoGrades');
+    console.log('historicoGradesSalvo', historicoGradesSalvo);
     if (historicoGradesSalvo) {
       setHistoricoGrades(JSON.parse(historicoGradesSalvo));
     }
@@ -119,17 +119,8 @@ const Grade = () => {
             Visualize sua grade horária completa com todos os detalhes
           </p>
         </div>
-        {gradeAtual.length > 0 && (
-          <div className="flex flex-col items-end gap-2 w-full md:w-auto">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleSalvarGrade}
-              className="flex items-center gap-2 w-full md:w-auto"
-            >
-              <Download className="w-4 h-4" />
-              Salvar Grade
-            </Button>
+        <div className="flex flex-col items-end gap-2 w-full md:w-auto">
+          {Object.keys(historicoGrades).length > 0 && (
             <Button
               variant="outline"
               size="sm"
@@ -139,17 +130,31 @@ const Grade = () => {
               <History className="w-4 h-4" />
               Histórico
             </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleLimparGrade}
-              className="flex items-center gap-2 w-full md:w-auto"
-            >
-              <Trash2 className="w-4 h-4" />
-              Limpar Grade
-            </Button>
-          </div>
-        )}
+          )}
+          {gradeAtual.length > 0 && (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleSalvarGrade}
+                className="flex items-center gap-2 w-full md:w-auto"
+              >
+                <Download className="w-4 h-4" />
+                Salvar Grade
+              </Button>
+              
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleLimparGrade}
+                className="flex items-center gap-2 w-full md:w-auto"
+              >
+                <Trash2 className="w-4 h-4" />
+                Limpar Grade
+              </Button>
+              </>
+          )}
+        </div>
       </div>
 
       {/* Grade Section */}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,14 +1,11 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { 
   Calculator, 
   BookOpen,
   ExternalLink,
   Calendar,
-  Grid3X3,
   Download,
-  Share2,
   Clock,
   Filter,
   Users,

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 
 const NotFound = () => {
   return (
-    <div className="min-h-screen flex items-center justify-center p-4">
+    <div className="flex items-center justify-center p-12">
       <Card className="w-full max-w-md text-center">
         <CardHeader>
           <div className="mx-auto mb-4 p-3 bg-muted rounded-full w-fit">
@@ -30,7 +30,7 @@ const NotFound = () => {
             </Button>
             
             <Button variant="outline" asChild>
-              <Link to="/conversao">
+              <Link to="/planejador">
                 <ArrowLeft className="w-4 h-4 mr-2" />
                 Conversão Simples
               </Link>

--- a/src/pages/PlanejadorSemestral.tsx
+++ b/src/pages/PlanejadorSemestral.tsx
@@ -3,7 +3,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Filter } from "lucide-react";
 import { 
   Calendar, 
@@ -11,14 +10,10 @@ import {
   Trash2, 
   CheckCircle,
   FileText,
-  Users,
-  Clock,
   BookOpen,
-  AlertTriangle,
   ExternalLink,
   Calculator,
   History,
-  Download
 } from "lucide-react";
 import { parseSigaaText, turmaToDisciplina, Turma, parseHorarios, Disciplina } from "@/utils/sigaaParser";
 import { GradeHoraria } from "@/components/GradeHoraria";

--- a/src/pages/PlanejadorSemestral.tsx
+++ b/src/pages/PlanejadorSemestral.tsx
@@ -823,8 +823,8 @@ const PlanejadorSemestral = () => {
                       </CardDescription>
                     </CardHeader>
                     <CardContent className="space-y-4">
-                      {disciplinas.map((disciplina) => (
-                        <div key={disciplina.codigo} className="border rounded-lg p-4 bg-muted/30">
+                      {disciplinas.map((disciplina, idx) => (
+                        <div key={idx} className="border rounded-lg p-4 bg-muted/30">
                           <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-4">
                             <div>
                               <h3 className="font-semibold text-lg">{disciplina.codigo}</h3>
@@ -893,9 +893,9 @@ const PlanejadorSemestral = () => {
                     </CardHeader>
                     <CardContent>
                       <div className="flex flex-wrap gap-2">
-                        {historico.map((codigo) => (
+                        {historico.map((codigo, idx) => (
                           <button
-                            key={codigo}
+                            key={idx}
                             onClick={() => handleHistoricoClick(codigo)}
                             className="px-3 py-1 bg-blue-100 text-blue-800 rounded-lg text-sm hover:bg-blue-200 transition-colors"
                           >
@@ -1212,9 +1212,9 @@ const PlanejadorSemestral = () => {
                             })
                           )
                         )
-                        .map((disciplina) => (
+                        .map((disciplina, idx) => (
                           <div 
-                            key={disciplina.codigo}
+                            key={idx}
                             className="p-3 md:p-4 border rounded-lg cursor-pointer hover:bg-muted/50 transition-colors"
                             onClick={() => setSelectedTurma(disciplina.turmas[0])}
                           >
@@ -1251,9 +1251,9 @@ const PlanejadorSemestral = () => {
                   </CardHeader>
                   <CardContent>
                     <div className="flex flex-wrap gap-2">
-                      {historicoCursos.map((nomeCurso) => (
+                      {historicoCursos.map((nomeCurso, idx) => (
                         <button
-                          key={nomeCurso}
+                          key={idx}
                           onClick={() => handleHistoricoCursosClick(nomeCurso)}
                           className="px-3 py-1 bg-indigo-100 text-indigo-800 rounded-lg text-sm hover:bg-indigo-200 transition-colors"
                         >
@@ -1437,8 +1437,8 @@ const PlanejadorSemestral = () => {
                         </div>
                       </div>
                       <div className="flex flex-wrap gap-1">
-                        {disciplinas.slice(0, 5).map((disciplina) => (
-                          <span key={disciplina.codigo} className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
+                        {disciplinas.slice(0, 5).map((disciplina, idx) => (
+                          <span key={idx} className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
                             {disciplina.codigo}
                           </span>
                         ))}

--- a/src/pages/PlanejadorSemestral.tsx
+++ b/src/pages/PlanejadorSemestral.tsx
@@ -44,10 +44,8 @@ const PlanejadorSemestral = () => {
   const [disciplinas, setDisciplinas] = useState<Disciplina[]>([]);
   const [historico, setHistorico] = useState<string[]>([]);
   const [historicoDisciplinas, setHistoricoDisciplinas] = useState<Disciplina[]>([]);
-  const [isMobile, setIsMobile] = useState(false);
   const [showFormatoEsperado, setShowFormatoEsperado] = useState(false);
   const [showInstrucoes, setShowInstrucoes] = useState(false);
-  const [showConversaoCompleta, setShowConversaoCompleta] = useState(true);
   const [showInputSection, setShowInputSection] = useState(true);
   
   // Estados para histórico de cursos consultados
@@ -57,19 +55,6 @@ const PlanejadorSemestral = () => {
   // Estados para histórico de grades salvas
   const [historicoGrades, setHistoricoGrades] = useState<{ [key: string]: Disciplina[] }>({});
   const [showHistoricoGrades, setShowHistoricoGrades] = useState(false);
-  const [nomeGradeAtual, setNomeGradeAtual] = useState("");
-
-  // Detecta se é mobile
-  useEffect(() => {
-    const checkIsMobile = () => {
-      setIsMobile(window.innerWidth < 768);
-    };
-    
-    checkIsMobile();
-    window.addEventListener('resize', checkIsMobile);
-    
-    return () => window.removeEventListener('resize', checkIsMobile);
-  }, []);
 
   const diasSemana = ["SEG", "TER", "QUA", "QUI", "SEX", "SAB"];
   const mapSiglaParaNome = {

--- a/src/utils/sigaaParser.ts
+++ b/src/utils/sigaaParser.ts
@@ -100,7 +100,7 @@ export function parseSigaaText(text: string): Turma[] {
         vagas = vagas ? vagas.replace(/\s+/g, ' ').trim() : '';
         turma = turma ? turma : '(Sem informação)';
         docente = docente ? docente : '(Sem informação)';
-        vagas = vagas && !isNaN(Number(vagas)) ? parseInt(vagas) : 0;
+        const vagasNum = vagas && !isNaN(Number(vagas)) ? parseInt(vagas) : 0;
         
         // Valida se o horário está no formato correto (deve conter códigos como 24T34, 7M456, etc.)
         if (horariosStr.match(/\d+[MTN]\d+/)) {
@@ -112,7 +112,7 @@ export function parseSigaaText(text: string): Turma[] {
             periodo: periodo,
             turma: turma,
             docente: docente,
-            vagas: vagas,
+            vagas: vagasNum,
             horarios: horariosStr || '(Sem informação)',
             dataInicio: dataInicio || '(Sem informação)',
             dataFim: dataFim || '(Sem informação)'
@@ -158,16 +158,16 @@ export function parseSigaaText(text: string): Turma[] {
           if (parts.length >= 6) {
             const periodo = parts[0];
             let turma = parts[1];
-            let vagas = parts[parts.length - 3];
+            let vagasStr = parts[parts.length - 3];
             const horariosStr = parts[parts.length - 2];
             const datas = parts[parts.length - 1];
             let docente = parts.slice(2, parts.length - 3).join(' ');
             turma = turma ? turma.replace(/\s+/g, ' ').trim() : '';
             docente = docente ? docente.replace(/\s+/g, ' ').trim() : '';
-            vagas = vagas ? vagas.replace(/\s+/g, ' ').trim() : '';
+            vagasStr = vagasStr ? vagasStr.replace(/\s+/g, ' ').trim() : '';
             turma = turma ? turma : '(Sem informação)';
             docente = docente ? docente : '(Sem informação)';
-            vagas = vagas && !isNaN(Number(vagas)) ? parseInt(vagas) : 0;
+            const vagasNum = vagasStr && !isNaN(Number(vagasStr)) ? parseInt(vagasStr) : 0;
             // Valida se o horário está no formato correto
             if (horariosStr.match(/\d+[MTN]\d+/) && datas.includes('(') && datas.includes(')')) {
               const [dataInicio, dataFim] = datas.replace(/[()]/g, '').split(' - ');
@@ -177,7 +177,7 @@ export function parseSigaaText(text: string): Turma[] {
                 periodo: periodo || '(Sem informação)',
                 turma: turma,
                 docente: docente,
-                vagas: vagas,
+                vagas: vagasNum,
                 horarios: horariosStr || '(Sem informação)',
                 dataInicio: dataInicio || '(Sem informação)',
                 dataFim: dataFim || '(Sem informação)'
@@ -285,32 +285,4 @@ export function detectConflicts(disciplinas: Disciplina[]): { [key: string]: str
   });
   
   return conflicts;
-}
-
-export function gerarHorariosLegiveis(disciplina: Disciplina): string {
-  const horariosPorDia: { [dia: string]: Array<{ horarioInicio: string; horarioFim: string }> } = {};
-  
-  // Agrupa horários por dia
-  disciplina.horarios.forEach(horario => {
-    if (!horariosPorDia[horario.dia]) {
-      horariosPorDia[horario.dia] = [];
-    }
-    horariosPorDia[horario.dia].push({
-      horarioInicio: horario.horarioInicio || '',
-      horarioFim: horario.horarioFim || ''
-    });
-  });
-  
-  // Gera texto legível
-  const dias = Object.keys(horariosPorDia);
-  if (dias.length === 0) return 'Horários não definidos';
-  
-  // Formata cada dia com seus horários
-  const diasFormatados = dias.map(dia => {
-    const horarios = horariosPorDia[dia];
-    const horario = horarios[0]; // Pega o primeiro horário do dia
-    return `${dia} ${horario.horarioInicio} às ${horario.horarioFim}`;
-  });
-  
-  return diasFormatados.join('\n');
 }


### PR DESCRIPTION
- Removi vários imports/hooks/funções não utilizadas
- Corrigi um redirecionamento para rota inexistente
- Agrupei os horários das disciplinas em 1 evento só no calendário. Ficou assim:
<img width="1490" height="531" alt="image" src="https://github.com/user-attachments/assets/b45c733a-9eaf-4dbf-9168-f14fecdb3bf4" />


- Adicionei uma seta para expandir/retrair o detalhamento de conflitos na grade: 
<img width="516" height="222" alt="image" src="https://github.com/user-attachments/assets/17275d3d-e445-4808-bd3c-7549cfad612d" />

- Troquei algumas keys para usar o índice ao invés do código da disciplina, pois pode haver mais de 1 turma e a key deve ser única
- Corrigi alguns erros de TypeScript
